### PR TITLE
chore: update release workflow to OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
     steps:
       - uses: actions/checkout@v5
@@ -14,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       
       - name: Install dependencies
@@ -28,5 +29,3 @@ jobs:
 
       - name: Publish to npmjs
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This change removes token based authentication in favour of [Trusted Publishers](https://docs.npmjs.com/trusted-publishers) for NPM